### PR TITLE
Add integration test for cross-assembly DiaSession

### DIFF
--- a/v2x_net45/AbstractTestClass.cs
+++ b/v2x_net45/AbstractTestClass.cs
@@ -1,0 +1,7 @@
+﻿using Xunit;
+
+public abstract class AbstractTestClass
+{
+    [Fact]
+    public void TestHasSourceInfo() { } // made concrete by v2x_net45_referencingproject; should not show under v2x_net45, not in the External category
+}

--- a/v2x_net45/v2x_net45.csproj
+++ b/v2x_net45/v2x_net45.csproj
@@ -58,6 +58,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AbstractTestClass.cs" />
     <Compile Include="BasicTests.cs" />
     <Compile Include="DeserializationFailureTests.cs" />
     <Compile Include="FixtureFailureTests.cs" />

--- a/v2x_net45_referencingproject/ConcreteTestClass.cs
+++ b/v2x_net45_referencingproject/ConcreteTestClass.cs
@@ -1,0 +1,3 @@
+﻿public class ConcreteTestClass : AbstractTestClass
+{
+}

--- a/v2x_net45_referencingproject/Properties/AssemblyInfo.cs
+++ b/v2x_net45_referencingproject/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("v2x_net45_referencingproject")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("v2x_net45_referencingproject")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b15afc6f-d6da-4f24-b120-0757651c68d4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/v2x_net45_referencingproject/v2x_net45_referencingproject.csproj
+++ b/v2x_net45_referencingproject/v2x_net45_referencingproject.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B15AFC6F-D6DA-4F24-B120-0757651C68D4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>v2x_net45_referencingproject</RootNamespace>
+    <AssemblyName>v2x_net45_referencingproject</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ConcreteTestClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\v2x_net45\v2x_net45.csproj">
+      <Project>{06d874bc-29fe-4b68-aa7f-b4654aa4520a}</Project>
+      <Name>v2x_net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/xunit.integration.sln
+++ b/xunit.integration.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 14.0.23107.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "v1_net20", "v1_net20\v1_net20.csproj", "{AA40B46D-EB27-43F5-8CA4-EC5758959BC7}"
 EndProject
@@ -63,6 +63,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "v21_UWP", "v21_UWP\v21_UWP.csproj", "{B395D733-D3E3-404F-B978-3429E4E1E603}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "v2x_NetCoreApp", "v2x_NetCoreApp\v2x_NetCoreApp.xproj", "{24DACD61-CDB4-4EDA-9D9F-9D2184D66A00}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "v2x_net45_referencingproject", "v2x_net45_referencingproject\v2x_net45_referencingproject.csproj", "{B15AFC6F-D6DA-4F24-B120-0757651C68D4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1518,6 +1520,62 @@ Global
 		{24DACD61-CDB4-4EDA-9D9F-9D2184D66A00}.Release|x64.Build.0 = Release|Any CPU
 		{24DACD61-CDB4-4EDA-9D9F-9D2184D66A00}.Release|x86.ActiveCfg = Release|Any CPU
 		{24DACD61-CDB4-4EDA-9D9F-9D2184D66A00}.Release|x86.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|ARM.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|iPhone.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|Mixed Platforms.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|x64.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|x64.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|x86.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Ad-Hoc|x86.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|Any CPU.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|ARM.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|ARM.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|iPhone.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|iPhone.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|Mixed Platforms.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|x64.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|x64.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|x86.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.AppStore|x86.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|ARM.Build.0 = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Debug|x86.Build.0 = Debug|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|ARM.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|ARM.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|iPhone.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|x64.Build.0 = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1549,5 +1607,6 @@ Global
 		{41070331-4C7C-43BE-A0E4-D1E95E13F00F} = {E570106E-0090-4CB8-8286-ED0B766AE68D}
 		{B395D733-D3E3-404F-B978-3429E4E1E603} = {41070331-4C7C-43BE-A0E4-D1E95E13F00F}
 		{24DACD61-CDB4-4EDA-9D9F-9D2184D66A00} = {687D1359-0317-4D26-BC5F-6612B8C657DA}
+		{B15AFC6F-D6DA-4F24-B120-0757651C68D4} = {687D1359-0317-4D26-BC5F-6612B8C657DA}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This is a companion PR for [#924](https://github.com/xunit/xunit/pull/924). It adds a testcase to the net45 group, which will incorrectly show up in the External category unless the other PR is merged.